### PR TITLE
 Extension should offer to install the "opa" executable when it's not found

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "url": "https://github.com/tsandall/vscode-opa.git"
     },
     "description": "Develop, test, debug, and analyze policies for the Open Policy Agent project.",
-    "version": "0.0.3",
+    "version": "0.0.4",
     "publisher": "tsandall",
     "engines": {
         "vscode": "^1.21.0"

--- a/package.json
+++ b/package.json
@@ -46,6 +46,17 @@
                 "title": "OPA: Trace Selection"
             }
         ],
+        "configuration": {
+            "type": "object",
+            "title": "OPA Configuration",
+            "properties": {
+                "opa.path": {
+                    "type": ["string", "null"],
+                    "default": null,
+                    "description": "Path of the OPA executable."
+                }
+            }
+        },
         "languages": [
             {
                 "id": "rego",

--- a/src/install-opa.ts
+++ b/src/install-opa.ts
@@ -1,0 +1,192 @@
+'use strict';
+
+import * as fs from 'fs';
+import * as http from 'http';
+import * as https from 'https';
+import * as os from 'os';
+import * as path from 'path';
+import { URL } from 'url';
+import * as vscode from 'vscode';
+
+import { opaOutputChannel } from './extension';
+
+let installDeclined = false;
+
+export function promptForInstall() {
+    if (installDeclined) {
+        return;
+    }
+    vscode.window.showInformationMessage('OPA executable is missing from your $PATH or \'opa.path\' is not set to the correct path. Would you like to install OPA?', 'Install')
+        .then((selection) => {
+            if (selection === 'Install') {
+               install();
+            } else {
+                installDeclined = true;
+            }
+        });
+}
+
+async function install() {
+    opaOutputChannel.clear();
+    opaOutputChannel.show(true);
+
+    opaOutputChannel.appendLine('Getting latest OPA release for your platform...');
+    let url;
+    try {
+        url = await getOpaDownloadUrl();
+        opaOutputChannel.appendLine(`Found latest OPA release: ${url}`);
+        if (url === null || url === undefined || url.toString().trim() === '') {
+            opaOutputChannel.appendLine('Could not find the latest OPA release for your platform');
+            return;
+        }
+    } catch (e) {
+        opaOutputChannel.appendLine('Something went wrong while getting the latest OPA release:');
+        opaOutputChannel.appendLine(e);
+        return;
+    }
+
+    opaOutputChannel.appendLine('Downloading OPA executable...');
+    let path;
+    try {
+        path = await downloadFile(url);
+        opaOutputChannel.appendLine(`OPA executable downloaded to ${path}`);
+    } catch (e) {
+        opaOutputChannel.appendLine('Something went wrong while downloading the OPA executable:');
+        opaOutputChannel.appendLine(e);
+        return;
+    }
+
+    opaOutputChannel.appendLine('Changing file mode to 0755 to allow execution...');
+    try {
+        await vscode.workspace.getConfiguration('opa').update('path', path, true);
+        fs.chmodSync(path, 0o755);
+    } catch (e) {
+        opaOutputChannel.appendLine(e);
+        return;
+    }
+
+    opaOutputChannel.appendLine(`Setting 'opa.path' to '${path}'...`);
+    try {
+        await vscode.workspace.getConfiguration('opa').update('path', path, true);
+    } catch (e) {
+        opaOutputChannel.appendLine('Something went wrong while saving the \'opa.path\' setting:');
+        opaOutputChannel.appendLine(e);
+        return;
+    }
+    opaOutputChannel.appendLine('Done!');
+}
+
+// Downloads a file given a URL
+// Returns a Promise that resolves to the absolute file path when the download is complete
+async function downloadFile(url: URL): Promise<string> {
+    // Use the user's home directory as the default base directory
+    const dest = os.homedir();
+    // Get the absolute path to the location where OPA will be downloaded
+    const fullPath = path.resolve(dest, getOPAExecutableName());
+    const outFile = fs.createWriteStream(fullPath);
+
+    return new Promise<string>((resolve, reject) => {
+        const writeFile = (res: http.IncomingMessage) => {
+            // Lame progress bar
+            res.on('data', (chunk) => opaOutputChannel.append('.'))
+               .on('end', () => opaOutputChannel.appendLine(''));
+            // Stream downloaded data straight to file
+            res.pipe(outFile);
+            outFile.on('finish', () => {
+                outFile.close();
+                resolve(fullPath);
+            });
+        };
+        // TODO: Honor HTTP proxy settings from `vscode.workspace.getConfiguration('http').get('proxy')`
+        https.get(url, (res: http.IncomingMessage) => {
+            // Github redirects to an AWS S3 url
+            if (res.statusCode && res.statusCode >= 300 && res.statusCode < 400) {
+                const { location } = res.headers;
+                if (location) {
+                    https.get(new URL(location), (nextRes) => writeFile(nextRes))
+                        .on('error', (e) => reject(e));
+                } else {
+                    reject(`Bad redirect from ${url.toString}`);
+                }
+            } else {
+                writeFile(res);
+            }
+        })
+        .on('error', (e) => reject(e));
+    });
+}
+
+async function getOpaDownloadUrl(): Promise<URL> {
+    return new Promise<URL>((resolve, reject) => {
+        // TODO: Honor HTTP proxy settings from `vscode.workspace.getConfiguration('http').get('proxy')`
+        https.get({
+            hostname:'api.github.com',
+            path: '/repos/open-policy-agent/opa/releases/latest',
+            headers: {
+                'User-Agent': 'node.js',
+                'Authorization': `token ${getToken()}`
+            }
+         }, (res: http.IncomingMessage) => {
+             let rawData = '';
+             res.on('data', (d: any) => {
+                 rawData += d;
+             });
+             res.on('end', () => {
+                 try {
+                    const release = JSON.parse(rawData);
+                    const url = getUrlFromRelease(release);
+                    resolve(new URL(url));
+                 } catch (e) {
+                     reject(e);
+                 }
+             });
+         }).on('error', (e: any) => reject(e));
+    });
+}
+
+function getUrlFromRelease(release: {assets: {name: string, browser_download_url: string}[]}): string {
+    // release.assets.name contains {'darwin', 'linux', 'windows'}
+    const assets = release.assets || [];
+    const os = process.platform;
+    let targetAsset: {browser_download_url: string};
+    switch (os) {
+        case 'darwin':
+            targetAsset = assets.filter((asset: {name: string}) => asset.name.indexOf('darwin') !== -1)[0];
+            break;
+        case 'linux':
+            targetAsset = assets.filter((asset: {name: string}) => asset.name.indexOf('linux') !== -1)[0];
+            break;
+        case 'win32':
+            targetAsset = assets.filter((asset: {name: string}) => asset.name.indexOf('windows') !== -1)[0];
+            break;
+        default:
+            targetAsset = {browser_download_url: ''};
+    }
+    return targetAsset.browser_download_url;
+}
+
+function getOPAExecutableName(): string {
+    const os = process.platform;
+    switch (os) {
+        case 'darwin':
+        case 'linux':
+            return 'opa';
+        case 'win32':
+            return 'opa.exe';
+        default:
+            return 'opa';
+    }
+}
+
+function getToken(): string {
+    // Need an OAuth token to access Github because
+    // this gets around the ridiculously low
+    // anonymous access rate limits (60 requests/sec/IP)
+    // This token only gives access to "public_repo" and "repo:status" scopes
+    return  ["0", "0", "b", "6", "2", "d", "1",
+    "0", "4", "d", "8", "5", "4", "9",
+    "4", "b", "d", "6", "e", "e", "9",
+    "5", "f", "1", "7", "1", "b", "d",
+    "0", "2", "3", "c", "e", "4", "a",
+    "3", "9", "a", "0", "6"].join('');
+}

--- a/src/opa.ts
+++ b/src/opa.ts
@@ -1,0 +1,77 @@
+'use strict';
+
+import cp = require('child_process');
+const commandExistsSync = require('command-exists').sync;
+import * as vscode from 'vscode';
+
+import { promptForInstall } from './install-opa';
+import { getImports, getPackage } from './util';
+
+/**
+ * Helpers for executing OPA as a subprocess.
+ */
+
+export function parse(opaPath: string, path: string, cb: (pkg: string, imports: string[]) => void) {
+    run(opaPath, ['parse', path, '--format', 'json'], '', (error: string, result: any) => {
+        if (error !== '') {
+            vscode.window.showErrorMessage(error);
+        } else {
+            let pkg = getPackage(result);
+            let imports = getImports(result);
+            cb(pkg, imports);
+        }
+    });
+}
+
+// run executes the OPA binary at path with args and stdin.  The callback is
+// invoked with an error message on failure or JSON object on success.
+export function run(path: string, args: string[], stdin: string, cb: (error: string, result: any) => void) {
+    runWithStatus(path, args, stdin, (code: number, stderr: string, stdout: string) => {
+        if (code !== 0) {
+            cb(stderr, '');
+        } else {
+            cb('', JSON.parse(stdout));
+        }
+    });
+}
+
+// runWithStatus executes the OPA binary at path with args and stdin. The
+// callback is invoked with the exit status, stderr, and stdout buffers.
+export function runWithStatus(path: string, args: string[], stdin: string, cb: (code: number, stderr: string, stdout: string) => void) {
+    const opaPath = vscode.workspace.getConfiguration('opa').get<string>('path');
+    const existsOnPath = commandExistsSync(path);
+    const existsInUserSettings = opaPath !== null && commandExistsSync(opaPath);
+
+    if (!(existsOnPath || existsInUserSettings)) {
+        promptForInstall();
+        return;
+    }
+
+    if (existsInUserSettings && opaPath !== undefined) {
+        // Prefer OPA in User Settings to the one installed on $PATH
+        path = opaPath;
+    }
+
+    let proc = cp.spawn(path, args);
+
+    proc.stdin.write(stdin);
+    proc.stdin.end();
+    let stdout = "";
+    let stderr = "";
+
+    proc.stdout.on('data', (data) => {
+        stdout += data;
+    });
+
+    proc.stderr.on('data', (data) => {
+        stderr += data;
+    });
+
+    proc.on('exit', (code, signal) => {
+        console.log("code:", code);
+        console.log("stdout:", stdout);
+        console.log("stderr:", stderr);
+        cb(code, stderr, stdout);
+    });
+
+}

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,0 +1,48 @@
+'use strict';
+
+/**
+ * String helpers for OPA types.
+ */
+export function getPackage(parsed: any): string {
+    return getPathString(parsed["package"].path.slice(1));
+}
+
+export function getImports(parsed: any): string[] {
+    if (parsed.imports !== undefined) {
+        return parsed.imports.map((x: any) => {
+            let str = getPathString(x.path.value);
+            if (!x.alias) {
+                return str;
+            }
+            return str + " as " + x.alias;
+        });
+    }
+    return [];
+}
+
+export function getPathString(path: any): string {
+    let i = -1;
+    return path.map((x: any) => {
+        i++;
+        if (i === 0) {
+            return x.value;
+        } else {
+            if (x.value.match('^[a-zA-Z_][a-zA-Z_0-9]*$')) {
+                return "." + x.value;
+            }
+            return '["' + x.value + '"]';
+        }
+    }).join('');
+}
+
+export function getPrettyTime(ns: number): string {
+    let seconds = ns / 1e9;
+    if (seconds >= 1) {
+        return seconds.toString() + 's';
+    }
+    let milliseconds = ns / 1e6;
+    if (milliseconds >= 1) {
+        return milliseconds.toString() + 'ms';
+    }
+    return (ns / 1e3).toString() + 'µs';
+}


### PR DESCRIPTION
- Introduce new 'opa.path' configuration
- Refactor opa-related helpers into opa.ts
- Refactor display utilities into util.ts
- Consolidate to using a single output channel called "OPA"
- Introduce install-opa module which will prompt to install, fetch releases from GH, choose appropriate release and install it
- Tested on Linux (Ubuntu 18.04) and Mac OS X 10.12.6 with VS Code 1.23.1
- TODO: Test on windows pls?