### PR TITLE
syntax: Fix the capatalisation on the rego grammer.


### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
             {
                 "language": "rego",
                 "scopeName": "source.rego",
-                "path": "./syntaxes/rego.tmLanguage"
+                "path": "./syntaxes/Rego.tmLanguage"
             }
         ]
     },


### PR DESCRIPTION


This fixes it so that the syntax is properly loaded on case-sensitive
fileystems, such as under linux.

