### PR TITLE
Add config for bundle root directories and bundleMode

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,11 @@ Search for "Open Policy Agent" in the Extensions (Shift ⌘ X) panel and then in
 | --- | --- | --- |
 | `opa.path` | `null` | Set path of OPA executable. |
 | `opa.checkOnSave` | `false` | Enable automatic checking of .rego files on save. |
+| `opa.roots` | `[${workspaceFolder}]` | List of paths to load as bundles for policy and data. Defaults to a single entry which is the current workspace root. The variable `${workspaceFolder}` will be resolved as the current workspace root. |
+| `opa.bundleMode`  | `true`  | Enable treating the workspace as a bundle to avoid loading erroneous data JSON/YAML files. It is _NOT_ recommended to disable this. |
+
+> For bundle documentation refer to [https://www.openpolicyagent.org/docs/latest/management/#bundle-file-format](https://www.openpolicyagent.org/docs/latest/management/#bundle-file-format).
+  Note that data files *MUST* be named either `data.json` or `data.yaml`.
 
 ## Tips
 
@@ -58,6 +63,12 @@ Bind the `OPA: Evaluate Package` command to a keyboard shortcut (e.g., ⌘ Shift
     "when": "editorLangId == rego"
 }
 ```
+
+### Loading arbitrary JSON/YAML as data
+
+If unable to use `data.json` or `data.yaml` files with `opa.bundleMode` enabled
+you can disable the configuration option and *ALL* `*.json` and `*.yaml` files
+will be loaded from the workspace
 
 ## Development
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -287,7 +287,7 @@
         "debug": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-            "integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
+            "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
             "dev": true,
             "requires": {
                 "ms": "2.0.0"
@@ -890,7 +890,7 @@
         "qs": {
             "version": "6.5.2",
             "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-            "integrity": "sha1-yzroBuh0BERYTvFUzo7pjUA/PjY="
+            "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
         },
         "querystringify": {
             "version": "2.1.1",
@@ -1015,7 +1015,7 @@
         "source-map": {
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-            "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
             "dev": true
         },
         "source-map-support": {

--- a/package.json
+++ b/package.json
@@ -68,14 +68,28 @@
 						"null"
 					],
 					"default": null,
-					"description": "Path of the OPA executable."
+					"description": "Path of the OPA executable. Defaults to null."
 				},
 				"opa.checkOnSave": {
 					"type": [
 						"boolean"
 					],
 					"default": false,
-					"description": "Run opa check on save"
+					"description": "Run opa check on save. Defaults to false"
+				},
+				"opa.roots": {
+					"type": [
+						"array"
+					],
+					"default": ["${workspaceFolder}"],
+					"description": "List of paths to load as bundles for policy and data. Defaults to [\"${workspaceFolder}\"]"
+				},
+				"opa.bundleMode": {
+					"type": [
+						"boolean"
+					],
+					"default": true,
+					"description": "Enable treating the workspace as a bundle."
 				}
 			}
 		},


### PR DESCRIPTION
This adds two new config options:

* `opa.roots` - Which defines directories to load as bundles when
  evaluating opa commands. This will default to the workspace root,
  and supports using a variable `${workspaceFolder}` for that.
* `opa.bundleMode` - Which defaults to true and enables using the
  `--bundle` option versus `--data` flag (what older versions of the
  plugin would do). This is intended as a stop-gap solution for
  projects that were successfully using the plugin and require that
  behavior.